### PR TITLE
Allow volume up to 1000%

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -54,3 +54,6 @@ DeleteInvoking = no
 
 ; Do NOT touch this if you don’t know what you are doing.
 DebugMode = no
+
+;Values above 100 creates distortion, enter a value between 1-1000
+MaxVolume = 100

--- a/config/example_permissions.ini
+++ b/config/example_permissions.ini
@@ -48,6 +48,11 @@
 ;    InstaSkip = no
 ;    Allows the user to skip a song without having to vote, like the owner.
 ;
+;    AllowHigherVolume = no
+;    Allows the user to go past 100% volume up to the MaxVolume set in options.
+;    Enabling this will allow users to distort the volume if the MaxVolume is set higher than 100.
+;
+;
 ;    DO NOT FORGET TO REMOVE THE ; WHEN ADDING USERS TO ROLES!!
 ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -61,6 +66,7 @@ MaxSongs = 0
 AllowPlaylists = yes
 MaxPlaylistLength = 150
 InstaSkip = no
+AllowHigherVolume = no
 
 ; This group has most permissions.
 [Admin]
@@ -71,6 +77,7 @@ MaxSongs = 0
 MaxPlaylistLength = 0
 AllowPlaylists = yes
 InstaSkip = yes
+AllowHigherVolume = yes
 
 ; This group can't use some commands, but otherwise has full permissions.
 [Moderator]
@@ -81,6 +88,7 @@ MaxSongs = 0
 MaxPlaylistLength = 0
 AllowPlaylists = yes
 InstaSkip = yes
+AllowHigherVolume = yes
 
 [Helper]
 CommandWhitelist = play queue np skip help joinhelpserver autoplaylist stream

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -78,6 +78,7 @@ class Config:
         self.delete_messages  = config.getboolean('MusicBot', 'DeleteMessages', fallback=ConfigDefaults.delete_messages)
         self.delete_invoking = config.getboolean('MusicBot', 'DeleteInvoking', fallback=ConfigDefaults.delete_invoking)
         self.debug_mode = config.getboolean('MusicBot', 'DebugMode', fallback=ConfigDefaults.debug_mode)
+        self.max_volume = config.getint('MusicBot', 'MaxVolume', fallback=ConfigDefaults.max_volume)
 
         self.blacklist_file = config.get('Files', 'BlacklistFile', fallback=ConfigDefaults.blacklist_file)
         self.auto_playlist_file = config.get('Files', 'AutoPlaylistFile', fallback=ConfigDefaults.auto_playlist_file)
@@ -153,6 +154,13 @@ class Config:
                 print("[Warning] AutojoinChannels data invalid, will not autojoin any channels")
                 self.autojoin_channels = set()
 
+        if self.max_volume < 1 or self.max_volume > 1000:
+            if self.max_volume < 1:
+                print("[Warning] Max Volume is {}%, which is less than 1%, defaulting to 100%.".format(self.max_volume))
+            elif self.max_volume > 1000:
+                print("[Warning] Max Volume is {}%, which is greater than 1000%, defaulting to 100%.".format(self.max_volume))
+            self.max_volume = 100
+
         self.delete_invoking = self.delete_invoking and self.delete_messages
 
         self.bound_channels = set(item.replace(',', ' ').strip() for item in self.bound_channels)
@@ -187,6 +195,7 @@ class ConfigDefaults:
     delete_messages = True
     delete_invoking = False
     debug_mode = False
+    max_volume = 100
 
     options_file = 'config/options.ini'
     blacklist_file = 'config/blacklist.txt'

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -21,6 +21,7 @@ class PermissionsDefaults:
     AllowPlaylists = True
     InstaSkip = False
 
+    AllowHigherVolume = False
 
 class Permissions:
     def __init__(self, config_file, grant_all=None):
@@ -101,6 +102,7 @@ class PermissionGroup:
 
         self.allow_playlists = section_data.get('AllowPlaylists', fallback=PermissionsDefaults.AllowPlaylists)
         self.instaskip = section_data.get('InstaSkip', fallback=PermissionsDefaults.InstaSkip)
+        self.allow_higher_volume = section_data.get('AllowHigherVolume', fallback=PermissionsDefaults.AllowHigherVolume)
 
         self.validate()
 
@@ -143,6 +145,9 @@ class PermissionGroup:
             self.instaskip, PermissionsDefaults.InstaSkip
         )
 
+        self.allow_higher_volume = configparser.RawConfigParser.BOOLEAN_STATES.get(
+            self.allow_higher_volume, PermissionsDefaults.AllowHigherVolume
+        )
 
     def add_user(self, uid):
         self.user_list.add(uid)

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -36,7 +36,7 @@ class PatchedBuff:
         frame = self.buff.read(frame_size)
 
         if self.volume != 1:
-            frame = self._frame_vol(frame, self.volume, maxv=2)
+            frame = self._frame_vol(frame, self.volume, maxv=10)
 
         if self.draw and not self.frame_count % self.frame_skip:
             # these should be processed for every frame, but "overhead"
@@ -49,7 +49,7 @@ class PatchedBuff:
 
         return frame
 
-    def _frame_vol(self, frame, mult, *, maxv=2, use_audioop=True):
+    def _frame_vol(self, frame, mult, *, maxv=10, use_audioop=True):
         if use_audioop:
             return audioop.mul(frame, 2, min(mult, maxv))
         else:


### PR DESCRIPTION
Edited bot.py, config.py, permissions.py and player.py to allow more volume than 100% and edited example_options.ini and example_permissions.ini so that they support the new max volume options and permissions. WARNING: Volumes above 100% create distortion. Above 750% is horrible. You have been warned.